### PR TITLE
Fix undefined reference to `call_pregraph_sparse'

### DIFF
--- a/sparsePregraph/inc/stdinc.h
+++ b/sparsePregraph/inc/stdinc.h
@@ -32,6 +32,7 @@
 #include <stddef.h>
 #include <time.h>
 #include <pthread.h>
+#include <unistd.h>
 using namespace std;
 
 


### PR DESCRIPTION
Error during compilation, already reported here: https://groups.google.com/d/topic/bgi-soap/cM9T1vvsPqw/discussion