### PR TITLE
Added missing "#include <unistd.h>" in several souces

### DIFF
--- a/sparsePregraph/build_preArc.cpp
+++ b/sparsePregraph/build_preArc.cpp
@@ -27,6 +27,8 @@
 #include "global.h"
 #include "multi_threads.h"
 
+#include <unistd.h>
+
 #include <math.h>
 #include "bam.h"
 #include "faidx.h"

--- a/sparsePregraph/multi_threads.cpp
+++ b/sparsePregraph/multi_threads.cpp
@@ -25,6 +25,8 @@
 #include "build_graph.h"
 #include "stdinc.h"
 
+#include <unistd.h>
+
 #include "build_preArc.h"
 
 void creatThrds ( pthread_t * threads, PARAMETER * paras )

--- a/sparsePregraph/pregraph_sparse.cpp
+++ b/sparsePregraph/pregraph_sparse.cpp
@@ -24,6 +24,8 @@
 #include "stdinc.h"
 #include "core.h"
 
+#include <unistd.h>
+
 #include "multi_threads.h"
 #include "build_graph.h"
 #include "build_edge.h"

--- a/standardPregraph/orderContig.c
+++ b/standardPregraph/orderContig.c
@@ -3202,7 +3202,7 @@ void ScafStat ( int len_cut, char * graphfile )
 	Singleton_Seq[Scaffold_Number] = 0;
 	Nucleotide = fgetc ( fp );
 
-	while ( Nucleotide != EOF )
+	while ( Nucleotide != (char) EOF ) /* Bug Fix */
 	{
 		if ( Nucleotide == '>' )
 		{
@@ -3529,7 +3529,7 @@ void ScafStat ( int len_cut, char * graphfile )
 	Singleton_Seq[Scaffold_Number] = 0;
 	Nucleotide = fgetc ( fp2 );
 
-	while ( Nucleotide != EOF )
+	while ( Nucleotide != (char) EOF ) /* Bug Fix */
 	{
 		if ( Nucleotide == '>' )
 		{


### PR DESCRIPTION
Needed to pick up declarations for usleep(3), optind(3), and getopt(3).
This should fix upstream (aquaskyline/SOAPdenovo2) issue #3 (make error on Ubuntu 14.04 LTS).