### PR TITLE
fixed issue #15. infinate loop if input file is not correct fastq format

### DIFF
--- a/standardPregraph/prlHashReads.c
+++ b/standardPregraph/prlHashReads.c
@@ -483,7 +483,13 @@ boolean prlRead2HashTable ( char *libfile, char *outfile )
                   if ( turn == 1 )
                     {
                       turn = 2;
-                      readseqInLib ( seqBuffer[read_c], next_name, & ( lenBuffer[read_c] ), readBuffer1, &start1, offset1, libNo );
+                      if( ! readseqInLib ( seqBuffer[read_c], next_name, & ( lenBuffer[read_c] ), readBuffer1, &start1, offset1, libNo ) )
+                      {
+                          fprintf ( stderr, "readseqInLib return error! please make sure input file is correct fastq/fasta file \n");
+                          *(readBuffer1+offset1)='\0';
+                          fprintf ( stderr, "invalid data left in buffer:\n%s\n",readBuffer1+start1);
+                          exit(-1);
+                      }
 
                       if ( ( ++i ) % 100000000 == 0 )
                         {
@@ -532,7 +538,13 @@ boolean prlRead2HashTable ( char *libfile, char *outfile )
                   if ( turn == 2 )
                     {
                       turn = 1;
-                      readseqInLib ( seqBuffer[read_c], next_name, & ( lenBuffer[read_c] ), readBuffer2, &start2, offset2, libNo );
+                      if( !readseqInLib ( seqBuffer[read_c], next_name, & ( lenBuffer[read_c] ), readBuffer2, &start2, offset2, libNo ) )
+                      {
+                          fprintf ( stderr, "readseqInLib return error! please make sure input file is correct fastq/fasta file \n");
+                          *(readBuffer2+offset2)='\0';
+                          fprintf ( stderr, "invalid data left in buffer:\n%s\n",readBuffer2+start2);
+                          exit(-1);
+                      }
 
                       if ( ( ++i ) % 100000000 == 0 )
                         {
@@ -608,7 +620,13 @@ boolean prlRead2HashTable ( char *libfile, char *outfile )
 
               while ( start < offset )
                 {
-                  readseqInLib ( seqBuffer[read_c], next_name, & ( lenBuffer[read_c] ), readBuffer1, &start, offset, libNo );
+                  if( ! readseqInLib ( seqBuffer[read_c], next_name, & ( lenBuffer[read_c] ), readBuffer1, &start, offset, libNo ) )
+                  {
+                      fprintf ( stderr, "readseqInLib return error! please make sure input file is correct fastq/fasta file \n");
+                      *(readBuffer1+offset)='\0';
+                      fprintf ( stderr, "invalid data left in buffer:\n%s\n",readBuffer1+start);
+                      exit(-1);
+                  }
 
                   if ( ( ++i ) % 100000000 == 0 )
                     {

--- a/standardPregraph/prlRead2path.c
+++ b/standardPregraph/prlRead2path.c
@@ -1001,7 +1001,13 @@ void prlRead2edge ( char *libfile, char *outfile )
                   if ( turn == 1 )
                     {
                       turn = 2;
-                      readseqInLib ( seqBuffer[read_c], next_name, & ( lenBuffer[read_c] ), readBuffer1, &start1, offset1, libNo );
+                     if( ! readseqInLib ( seqBuffer[read_c], next_name, & ( lenBuffer[read_c] ), readBuffer1, &start1, offset1, libNo ) )
+                      {
+                          fprintf ( stderr, "readseqInLib return error! please make sure input file is correct fastq/fasta file \n");
+                          *(readBuffer1+offset1)='\0';
+                          fprintf ( stderr, "invalid data left in buffer:\n%s\n",readBuffer1+start1);
+                          exit(-1);
+                      }
 
                       if ( ( ++i ) % 100000000 == 0 )
                         {
@@ -1078,7 +1084,13 @@ void prlRead2edge ( char *libfile, char *outfile )
                   if ( turn == 2 )
                     {
                       turn = 1;
-                      readseqInLib ( seqBuffer[read_c], next_name, & ( lenBuffer[read_c] ), readBuffer2, &start2, offset2, libNo );
+                      if( !readseqInLib ( seqBuffer[read_c], next_name, & ( lenBuffer[read_c] ), readBuffer2, &start2, offset2, libNo ) )
+                      {
+                          fprintf ( stderr, "readseqInLib return error! please make sure input file is correct fastq/fasta file \n");
+                          *(readBuffer2+offset2)='\0';
+                          fprintf ( stderr, "invalid data left in buffer:\n%s\n",readBuffer2+start2);
+                          exit(-1);
+                      }
 
                       if ( ( ++i ) % 100000000 == 0 )
                         {
@@ -1181,7 +1193,14 @@ void prlRead2edge ( char *libfile, char *outfile )
 
               while ( start < offset )
                 {
-                  readseqInLib ( seqBuffer[read_c], next_name, & ( lenBuffer[read_c] ), readBuffer1, &start, offset, libNo );
+                  if( ! readseqInLib ( seqBuffer[read_c], next_name, & ( lenBuffer[read_c] ), readBuffer1, &start, offset, libNo ) )
+                  {
+                      fprintf ( stderr, "readseqInLib return error! please makesure input file is correct fastq/fasta file \n");
+                      *(readBuffer1+offset)='\0';
+                      fprintf ( stderr, "invalid data left in buffer:\n%s\n",readBuffer1+start);
+                      exit(-1);
+                  }
+
 
                   if ( ( ++i ) % 100000000 == 0 )
                     {

--- a/standardPregraph/readseq1by1.c
+++ b/standardPregraph/readseq1by1.c
@@ -931,6 +931,10 @@ boolean readseqInLib ( char *src_seq, char *src_name, int *len_seq, char *buf, i
       if ( lib_array[i].paired == 1 )
         {
           readseqInBuf ( src_seq, src_name, len_seq, buf, start, offset );
+          if( *len_seq < 1 )
+          {
+            return 0;
+          }
 
           if ( lib_array[i].reverse )
             {
@@ -945,6 +949,10 @@ boolean readseqInLib ( char *src_seq, char *src_name, int *len_seq, char *buf, i
         {
           readseqInBuf ( src_seq, src_name, len_seq, buf, start, offset );
 
+          if( *len_seq < 1 )
+          {
+            return 0;
+          }
           if ( lib_array[i].reverse )
             {
               reverse2k ( src_seq, *len_seq );
@@ -961,6 +969,10 @@ boolean readseqInLib ( char *src_seq, char *src_name, int *len_seq, char *buf, i
       if ( lib_array[i].paired == 1 )
         {
           readseqfq ( src_seq, src_name, len_seq, buf, start, offset );
+          if( *len_seq < 1 )
+          {
+            return 0;
+          }
 
           if ( lib_array[i].reverse )
             {
@@ -974,6 +986,10 @@ boolean readseqInLib ( char *src_seq, char *src_name, int *len_seq, char *buf, i
       else
         {
           readseqfq ( src_seq, src_name, len_seq, buf, start, offset );
+          if( *len_seq < 1 )
+          {
+            return 0;
+          }
 
           if ( lib_array[i].reverse )
             {
@@ -989,10 +1005,18 @@ boolean readseqInLib ( char *src_seq, char *src_name, int *len_seq, char *buf, i
   if ( lib_array[i].curr_type == 6 )
     {
       readseqfq ( src_seq, src_name, len_seq, buf, start, offset );
+      if( *len_seq < 1 )
+      {
+          return 0;
+      }
     }
   else
     {
       readseqInBuf ( src_seq, src_name, len_seq, buf, start, offset );
+      if( *len_seq < 1 )
+      {
+          return 0;
+      }
     }
 
   /*


### PR DESCRIPTION
Add a extra garbage line at the end of a fastq file can trigger this bug.  Instead of into infinite loop , I fixed it by report the incorrect data and exit the program.